### PR TITLE
Calculated current limit

### DIFF
--- a/ESP_LED_MQTT/ESP_LED_MQTT.ino
+++ b/ESP_LED_MQTT/ESP_LED_MQTT.ino
@@ -113,10 +113,16 @@ void setup() {
   memcpy(ledLenStr, readFromEEPROM(nrLedsLen,nrLedsAddr),nrLedsLen);
   ledLen = atoi(ledLenStr);
   FastLED.addLeds<WS2812B, LED_DATA_PIN, GRB>(leds, ledLen);
-
+  
+  // calculate current limit
+  curLimit = ledLen * SINGLE_LED_CURRENT;
+  Serial.print("MAX current:");
+  Serial.println(curLimit);
   if(curLimit > MAX_CUR){
     curLimit = MAX_CUR;
   }
+  Serial.print("MAX current:");
+  Serial.println(curLimit);
   FastLED.setMaxPowerInVoltsAndMilliamps(5,curLimit);
 
   arrData[0] = 3; // go to standby

--- a/ESP_LED_MQTT/ESP_LED_MQTT.ino
+++ b/ESP_LED_MQTT/ESP_LED_MQTT.ino
@@ -116,13 +116,9 @@ void setup() {
   
   // calculate current limit
   curLimit = ledLen * SINGLE_LED_CURRENT;
-  Serial.print("MAX current:");
-  Serial.println(curLimit);
   if(curLimit > MAX_CUR){
     curLimit = MAX_CUR;
   }
-  Serial.print("MAX current:");
-  Serial.println(curLimit);
   FastLED.setMaxPowerInVoltsAndMilliamps(5,curLimit);
 
   arrData[0] = 3; // go to standby

--- a/ESP_LED_MQTT/config.h
+++ b/ESP_LED_MQTT/config.h
@@ -22,7 +22,8 @@
 #define nrLedsAddr 0
 
 // LED strip settings
-#define MAX_CUR 13000
+#define SINGLE_LED_CURRENT 60  //current of single WS2812B at RGB(255,255,255)
+#define MAX_CUR 13000 //MAX current allowed, set it so it's lower than what your power supply is capable of
 #define NUM_LEDS 300 //will only be used to set up array for fastLED library, so set the size as big as the longest LED strip will be
 #define LED_DATA_PIN 5 //D1, used to drive the LED strip
 


### PR DESCRIPTION
## Changes:

- added max current that single WS2812b consumes at full white to config

- added calculation that calculates max current by the number of LEDs configured

- if calculation exceeds max current defined in config file it's lowered to that current, in case entered number of LEDs is higher than your power supply can handle